### PR TITLE
Fix check for $JAVA_HOME

### DIFF
--- a/truststore_java.go
+++ b/truststore_java.go
@@ -30,7 +30,7 @@ type JavaTrust struct {
 // NewJavaTrust initializes a new JavaTrust if the environment has java installed.
 func NewJavaTrust() (*JavaTrust, error) {
 	home := os.Getenv("JAVA_HOME")
-	if home != "" {
+	if home == "" {
 		return nil, ErrTrustNotFound
 	}
 


### PR DESCRIPTION
Caddy (v2.1.1 h1:X9k1+ehZPYYrSqBvf/ocUgdLSRIuiNiMo7CvyGUQKeA=) fails for a host with the `tls internal` in its configuration, producing the following log messages:

```
caddy: [INFO][cache:0xc00007e420] Started certificate maintenance routine
caddy: {"level":"info","logger":"http","msg":"server is listening only on the HTTP port, so no automatic HTTPS will be applied to this server","server_name":"srv0","http_port":80}
caddy: {"level":"warn","logger":"pki.ca.local","msg":"installing root certificate (you might be prompted for password)","path":"storage:pki/authorities/local/root.crt"}
caddy: not NSS security databases found
caddy: failed to execute "keytool -list": exit status 1
caddy: keytool error: java.lang.Exception: Keystore file does not exist:
sudo: pam_unix(sudo:auth): conversation failed
sudo: pam_unix(sudo:auth): auth could not identify password for [caddy]
sudo:    caddy : user NOT in sudoers ; TTY=unknown ; PWD=/ ; USER=root ; COMMAND=bin/keytool -importcert -noprompt -keystore  -storepass changeit -file /tmp/truststore.430114816.pem -alias Caddy Local Authority - 2020 ECC Root 11111111111111111111111111111111111111
caddy: {"level":"error","logger":"pki.ca.local","msg":"failed to install root certificate","error":"failed to execute keytool: exit status 1","certificate_file":"storage:pki/authorities/local/root.crt"}
```

I traced the issue to the Java trust store's check for the `JAVA_HOME` environment variable, which seems to contain a logic error: the `ErrTrustNotFound` error should be returned when `JAVA_HOME` _is_ empty, right?

In my case `JAVA_HOME` wasn't set, but no error was returned and the [`Install()`](https://github.com/smallstep/truststore/blob/903b41c208c1fab27284c1d75790a2cbf4df731e/truststore_java.go#L70) eventually fails, because `t.cacertsPath` is empty.

This change wasn't tested, and I'm not even sure if this is all that would be required. Please adjust as you see fit. 🙂 