### PR TITLE
Add dependency auto-installation support for certain Linux platforms

### DIFF
--- a/truststore_linux.go
+++ b/truststore_linux.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -24,9 +25,31 @@ var (
 
 	// SystemTrustCommand is the command used to update the system truststore.
 	SystemTrustCommand []string
+
+	// whether or not the needed packages should be attemted to be installed
+	TryInstallCaCommand bool
+
+	// if the above is true, if we should also ignore the certs the repo is using
+	IgnoreSslForInstall bool
 )
 
 func init() {
+	setCommandAndFileVariables()
+
+	if os.Getenv("TRUSTSTORE_INSTALL_CA_PACKAGE") == "true" {
+		TryInstallCaCommand = true
+	} else {
+		TryInstallCaCommand = false
+	}
+
+	if os.Getenv("TRUSTSTORE_IGNORE_PACKAGE_CERTS") == "true" {
+		IgnoreSslForInstall = true
+	} else {
+		IgnoreSslForInstall = false
+	}
+}
+
+func setCommandAndFileVariables() {
 	switch {
 	case pathExists("/etc/pki/ca-trust/source/anchors/"):
 		SystemTrustFilename = "/etc/pki/ca-trust/source/anchors/%s.pem"
@@ -45,11 +68,15 @@ func init() {
 		SystemTrustCommand = []string{"trust", "extract-compat"}
 	}
 	if SystemTrustCommand != nil {
-		_, err := exec.LookPath(SystemTrustCommand[0])
-		if err != nil {
+		if !existsOnPath(SystemTrustCommand[0]) {
 			SystemTrustCommand = nil
 		}
 	}
+}
+
+func existsOnPath(binary string) bool {
+	_, err := exec.LookPath(binary)
+	return err == nil
 }
 
 func pathExists(path string) bool {
@@ -61,9 +88,74 @@ func systemTrustFilename(cert *x509.Certificate) string {
 	return fmt.Sprintf(SystemTrustFilename, strings.ReplaceAll(uniqueName(cert), " ", "_"))
 }
 
+func tryDetermineOsAndInstall() error {
+	if !TryInstallCaCommand {
+		return ErrNotSupported
+	}
+
+	debug("trying to determine OS package manager")
+
+	// RHEL is purposefully being ignored here - even their minimal container images include the required utils.
+
+	if existsOnPath("apk") {
+		debug("using apk/alpine")
+		cmd := CommandWithSudo(strings.Split("apk --no-cache add ca-certificates", " ")...)
+		if IgnoreSslForInstall {
+			debug("ignoring SSL for package install")
+			// we need to get the alpine version because apk doesn't have a way to just ignore SSL
+			// instead we need to force it to use the same repo but with HTTP
+			f, err := os.Open("/etc/alpine-release")
+			if err != nil {
+				return ErrNotSupported
+			}
+			buf := make([]byte, 4)
+			_, err = io.ReadAtLeast(f, buf, 4)
+			if err != nil {
+				return ErrNotSupported
+			}
+			cmd = CommandWithSudo(strings.Split(fmt.Sprintf("apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v%v/main add ca-certificates", string(buf[:4])), " ")...)
+		}
+		err := cmd.Run()
+		if err != nil {
+			return ErrNotSupported
+		}
+		setCommandAndFileVariables()
+		return nil
+	}
+
+	if existsOnPath("apt-get") {
+		debug("using apt-get/debian")
+		cmd := CommandWithSudo(strings.Split("apt-get update", " ")...)
+		if IgnoreSslForInstall {
+			debug("ignoring SSL for apt-get update")
+			cmd = CommandWithSudo(strings.Split("apt-get -o \"Acquire::https::Verify-Peer=false\" update", " ")...)
+		}
+		err := cmd.Run()
+		if err != nil {
+			return ErrNotSupported
+		}
+		cmd = CommandWithSudo(strings.Split("apt-get install -y ca-certificates", " ")...)
+		if IgnoreSslForInstall {
+			debug("ignoring SSL for package install")
+			cmd = CommandWithSudo(strings.Split("apt-get -o \"Acquire::https::Verify-Peer=false\" install -y ca-certificates", " ")...)
+		}
+		err = cmd.Run()
+		if err != nil {
+			return ErrNotSupported
+		}
+		setCommandAndFileVariables()
+		return nil
+	}
+
+	return ErrNotSupported
+}
+
 func installPlatform(filename string, cert *x509.Certificate) error {
 	if SystemTrustCommand == nil {
-		return ErrNotSupported
+		err := tryDetermineOsAndInstall()
+		if err != nil {
+			return err
+		}
 	}
 
 	data, err := os.ReadFile(filename)
@@ -90,7 +182,10 @@ func installPlatform(filename string, cert *x509.Certificate) error {
 
 func uninstallPlatform(filename string, cert *x509.Certificate) error {
 	if SystemTrustCommand == nil {
-		return ErrNotSupported
+		err := tryDetermineOsAndInstall()
+		if err != nil {
+			return err
+		}
 	}
 
 	cmd := CommandWithSudo("rm", "-f", systemTrustFilename(cert))


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature: Linux dependency auto-installation

#### Pain or issue this feature alleviates:

#20 

#### Is there documentation on how to use this feature? If so, where?

Unfortunately not. If you can point me where docs should go (if not just in the README), I'll gladly write them. It uses two environment variables: `TRUSTSTORE_INSTALL_CA_PACKAGE` and `TRUSTSTORE_IGNORE_PACKAGE_CERTS`. If set to `true`, the former attempts to install the needed packages for CA installation from the distro package manager, and the latter will do that while ignoring upstream cert validity. This is useful when you're behind corporate SSL inspection, which is my use-case.

#### In what environments or workflows is this feature supported?

This works for Debian-likes and Alpine. 

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

Anything that isn't a Linux distro. I should note that RHEL and its derivatives do not appear to need this, as they've ensured relevant packages are always available, even on minimal installs.

#### Supporting links/other PRs/issues:

#20 

---

Please let me know if any clean-up needs to be done. 

Changes I've made to the code:
- what used to be done in `init()` is now done in another function, `setCommandAndFileVariables()`, so they can be set again after attempting to install relevant packages
- there are now variables for `TRUSTSTORE_INSTALL_CA_PACKAGE` and `TRUSTSTORE_IGNORE_PACKAGE_CERTS`
- added an `existsOnPath()` function that returns true when a binary is on path, false when not - this is useful for package manager resolution, and also cleans up `setCommandAndFileVariables()` a bit
- `installPlatform()` and `uninstallPlatform()` now hit `tryDetermineOsAndInstall()`, a function that tries to install relevant packages if `TRUSTSTORE_INSTALL_CA_PACKAGE` is true

I've tested this internally with a pipeline that runs a binary using this library on these distros:
- Alpine 3.17
- Alpine 3.18
- Debian 12 (bookworm)
- RHEL UBI9 Minimal
- RHEL 9

The test downloaded a copy of my employer's CA certs, then tried to install them using this library. After that, it tried to verify an SSL connection that uses those certs. Permutations were added for the values of `TRUSTSTORE_INSTALL_CA_PACKAGE` and `TRUSTSTORE_IGNORE_PACKAGE_CERTS`.

Closes #20.