### PR TITLE
removes init $PATH checks from trustore_linux.go

### DIFF
--- a/truststore_linux.go
+++ b/truststore_linux.go
@@ -44,12 +44,6 @@ func init() {
 		SystemTrustFilename = "/etc/ssl/certs/%s.crt"
 		SystemTrustCommand = []string{"trust", "extract-compat"}
 	}
-	if SystemTrustCommand != nil {
-		_, err := exec.LookPath(SystemTrustCommand[0])
-		if err != nil {
-			SystemTrustCommand = nil
-		}
-	}
 }
 
 func pathExists(path string) bool {


### PR DESCRIPTION
Inspecting the PATH is not reliable since it can change when running sudo.

See #23 for context, and [this commit](https://github.com/FiloSottile/mkcert/commit/343aec289a131db121e8914a3b873ddf27766960) in the mkcert repo.

Closes #23.
